### PR TITLE
Ustream Video API の仕様変更に伴う修正

### DIFF
--- a/lib/goosetune/ustream.rb
+++ b/lib/goosetune/ustream.rb
@@ -1,6 +1,8 @@
 class Goosetune::Ustream
   def initialize
-    url = 'http://api.ustream.tv/json/user/6018269/listAllVideos/?limit=100'
+    # playyouhouse user_id: 6018269
+    # playyouhouse channel_id: 4509151
+    url = 'https://api.ustream.tv/channels/4509151/videos.json?limit=100'
     uri = URI.parse(URI.escape(url))
     json = Net::HTTP.get(uri)
     @response = JSON.parse(json)

--- a/lib/goosetune/ustream/video.rb
+++ b/lib/goosetune/ustream/video.rb
@@ -2,15 +2,40 @@ class Goosetune::Ustream::Video < Goosetune::Ustream
   def get_ustreams
     ustreams = {}
 
-    @response['results'].each do |entry|
+    @response['videos'].each do |entry|
+      # id: '90113779'
+      # title: 'Goose house UST LIVE #63-2'
+      # description: Recorded on 2016/07/30
+      # url: http://www.ustream.tv/recorded/90113779
+      # length: '5185.7578125'
+      # created_at: 1469878224
+      # file_size: '1229374451'
+      # views: 32533
+      # protect: public
+      # thumbnail:
+      #   default: https://ustvstaticcdn2-a.akamaihd.net/i/video/picture/0/1/90/90113/90113779/1_4509151_90113779,192x108,b,1:3.jpg
+      # media_urls:
+      #   flv: http://tcdn.ustream.tv/video/90113779?preset_id=1&e=1470772712&h=fa23151f306f32660b7f0a55f0020889&source=api
+      # links:
+      #   channel:
+      #     href: https://api.ustream.tv/channels/4509151.json
+      #     id: '4509151'
+      # tinyurl: http://ustre.am/:666I3
+      # schedule: 
+      # owner:
+      #   id: '6018269'
+      #   username: playyouhouse
+      #   picture: https://ustvstaticcdn1-a.akamaihd.net/i/user/picture/6/0/1/8/6018269/6018269_logo_______1347285093,48x48,r:1.jpg
+      # 
       video_snippet = {}
       id = entry['id']
       video_snippet[:id]          = entry['id'].chomp
       video_snippet[:title]       = entry['title'].chomp
       video_snippet[:url]         = entry['url'].chomp
-      video_snippet[:thumbnail]   = entry['imageUrl']['medium'].chomp
-      video_snippet[:published]   = entry['createdAt'].chomp
-      video_snippet[:view_counts] = entry['totalViews'].chomp
+      video_snippet[:thumbnail]   = entry['thumbnail']['default'].chomp
+      # created_at is unix timestamp
+      video_snippet[:published]   = Time.at( entry['created_at'] ).to_s.chomp
+      video_snippet[:view_counts] = entry['views']
       ustreams[id] = video_snippet
     end
 


### PR DESCRIPTION
refs https://twitter.com/GooseLikePachi/status/760836272566902785
## 概要

掲題の通り、UstreamAPIの仕様変更で従来のURLではアクセスできなくなった。

  `http://api.ustream.tv/json/user/6018269/listAllVideos/?limit=100`

  上記URLでアクセスすると以下のエラーとなる。
    `This call is currently unavailable. Please reach out to api@ustream.tv to learn more. (IP: 125.30.124.41)`
## どうするのか？

  Ustream の _Bloadcasting API の中のChannel API_ を使用する。
- refs http://developers.ustream.tv/broadcasting-api/channel.html
### chnannel api ではチャンネルIDが必要

  今まではplayyouhouseチャンネルのUserID(6018269) を使用していた。
  Channel APIではplayyouhouseチャンネルのChannelID(4509151)を使用する。
## 具体的には

以下URLを基点にする。

`https://api.ustream.tv/channels/4509151/videos.json`
`https://api.ustream.tv/channels/4509151/videos.xml`
### パラメータ

調査中。以下のパラメタは使えた。Gooseもアーカイブ数増えて2ページ目にいったぽい。
- ?limit=100&page=1
- ?limit=100&page=2
